### PR TITLE
Fix install in sandboxed environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,5 @@ clean:
 	-rm -f $(OBJECTS) $(BIN)
 
 install:
+	mkdir -p $(DESTDIR)/usr/bin/
 	cp $(BIN) $(DESTDIR)/usr/bin/


### PR DESCRIPTION
In sandboxed build systems (eg. Gentoo's Portage), make install fails because $(DESTDIR)/usr/bin does not exists. The directory should be assumed not existing and be created unconditionally.
